### PR TITLE
Don't remove other IP's from provisioning interface

### DIFF
--- a/set-static-ip
+++ b/set-static-ip
@@ -12,8 +12,6 @@ if [ -z "$PROVISIONING_IP" ]; then
     exit 1
 fi
 
-# Get rid of any DHCP addresses etc.
-/usr/sbin/ip address flush dev $PROVISIONING_INTERFACE
 # Need this to be long enough to bring up the pod with the ip refresh in it.
 # The refresh-static-ip container should lower this back to 10 seconds once it starts.
 # The only time this will actually be set for 5 minutes is if the containers fail to come up.


### PR DESCRIPTION
If the `podIP` is set to be on the provisioning network (it's not clear
to me how kubelet picks which IP to be for a pod that's using host networking), then when it gets
removed by the static IP manager and replaced with the 172.22.0.3
record, podIP is still set to the old invalid IP and heath checks start
failing and the cluster breaks.

From previous scouring of various bug reports, it looks like we were
using 192.168.111.x baremetal network for the podIP before, so maybe
something changed here. With this fix, e.g. running this before building
a cluster:

```
export IRONIC_STATIC_IP_MANAGER_LOCAL_IMAGE=https://github.com/stbenjam/static-ip-manager-image.git
```

We can get a successful install.