### PR TITLE
Toggle addr_gen_mode to 1 and back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/centos:centos7
 
-RUN yum install -y iproute && yum clean all
+RUN yum install -y iproute jq && yum clean all
 
 COPY ./set-static-ip /set-static-ip
 COPY ./refresh-static-ip /refresh-static-ip

--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -11,11 +11,24 @@ if [ -z "$PROVISIONING_INTERFACE" ]; then
   # hard dependency of forcing users to specify the interface, we detect
   # which network interface has the IP's from the machine network.
   IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
-  PROVISIONING_INTERFACE=$(ip route get "$IP_ONLY" | grep -Po '(?<=(dev )).*(?= src| proto)')
+
+  # See if we already have the IP on an interface
+  PROVISIONING_INTERFACE=$(ip -j addr | jq -r -c ".[].addr_info[] | select(.local == \"$IP_ONLY\") | .label")
+
+  # If not, let's figure out what interface it should go on
+  if [ -z "$PROVISIONING_INTERFACE" ]; then
+    PROVISIONING_INTERFACE=$(ip -j route get "$IP_ONLY" | jq -r '.[] | select(.dev != "lo") | .dev')
+  fi
 else
   # Get rid of any DHCP addresses only if we have a dedicated
   # provisioning interface
   /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+fi
+
+if [ -z "$PROVISIONING_INTERFACE" ]; then
+  ip addr show
+  echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
+  exit 1
 fi
 
 # In case the IP has lapsed since we set it in the init container.

--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -1,25 +1,31 @@
 #!/bin/bash -xe
 
-#PROVISIONING_INTERFACE='ens3'
-#PROVISIONING_IP='172.22.0.2'
-
-if [ -z "$PROVISIONING_INTERFACE" ]; then
-    echo "ERROR: PROVISIONING_INTERFACE environment variable unset."
-    exit 1
-fi
 if [ -z "$PROVISIONING_IP" ]; then
     echo "ERROR: PROVISIONING_IP environment variable unset."
     exit 1
 fi
 
+if [ -z "$PROVISIONING_INTERFACE" ]; then
+  # If no provisioning interface is specified, then we're probably in
+  # the mode where the provisioning network is optional, so to avoid a
+  # hard dependency of forcing users to specify the interface, we detect
+  # which network interface has the IP's from the machine network.
+  IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
+  PROVISIONING_INTERFACE=$(ip route get "$IP_ONLY" | grep -Po '(?<=(dev )).*(?= src| proto)')
+else
+  # Get rid of any DHCP addresses only if we have a dedicated
+  # provisioning interface
+  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+fi
+
 # In case the IP has lapsed since we set it in the init container.
-/usr/sbin/ip addr add $PROVISIONING_IP dev $PROVISIONING_INTERFACE valid_lft 10 preferred_lft 10 || true
+/usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
 
 while true; do
     # Having addr_gen_mode set to 1 doesn't appear to work and
     # ends up with the interface loosing its link-local IP periodically.
     echo 0 > /proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode
-    /usr/sbin/ip addr change $PROVISIONING_IP dev $PROVISIONING_INTERFACE valid_lft 10 preferred_lft 10
+    /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
     sleep 5
 done
 

--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -35,9 +35,11 @@ fi
 /usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
 
 while true; do
-    # Having addr_gen_mode set to 1 doesn't appear to work and
-    # ends up with the interface loosing its link-local IP periodically.
-    echo 0 > /proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1908302
+    # Toggling addr_gen_mode prompts the link local address to be reapplied in cases
+    # where it is lost.
+    ip -o addr show dev "$PROVISIONING_INTERFACE" scope link | grep -q " fe80::" || \
+    ( echo 1 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" ; echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" )
     /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
     sleep 5
 done

--- a/set-static-ip
+++ b/set-static-ip
@@ -11,11 +11,24 @@ if [ -z "$PROVISIONING_INTERFACE" ]; then
   # hard dependency of forcing users to specify the interface, we detect
   # which network interface has the IP's from the machine network.
   IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
-  PROVISIONING_INTERFACE=$(ip route get "$IP_ONLY" | grep -Po '(?<=(dev )).*(?= src| proto)')
+
+  # See if we already have the IP on an interface
+  PROVISIONING_INTERFACE=$(ip -j addr | jq -r -c ".[].addr_info[] | select(.local == \"$IP_ONLY\") | .label")
+
+  # If not, let's figure out what interface it should go on
+  if [ -z "$PROVISIONING_INTERFACE" ]; then
+    PROVISIONING_INTERFACE=$(ip -j route get "$IP_ONLY" | jq -r '.[] | select(.dev != "lo") | .dev')
+  fi
 else
   # Get rid of any DHCP addresses only if we have a dedicated
   # provisioning interface
   /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+fi
+
+if [ -z "$PROVISIONING_INTERFACE" ]; then
+  ip addr show
+  echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
+  exit 1
 fi
 
 # Need this to be long enough to bring up the pod with the ip refresh in it.

--- a/set-static-ip
+++ b/set-static-ip
@@ -1,20 +1,24 @@
 #!/bin/bash -xe
 
-#PROVISIONING_INTERFACE='ens3'
-#PROVISIONING_IP='172.22.0.2'
-
-if [ -z "$PROVISIONING_INTERFACE" ]; then
-    echo "ERROR: PROVISIONING_INTERFACE environment variable unset."
-    exit 1
-fi
 if [ -z "$PROVISIONING_IP" ]; then
     echo "ERROR: PROVISIONING_IP environment variable unset."
     exit 1
 fi
 
-# Get rid of any DHCP addresses etc.
-/usr/sbin/ip address flush dev $PROVISIONING_INTERFACE
+if [ -z "$PROVISIONING_INTERFACE" ]; then
+  # If no provisioning interface is specified, then we're probably in
+  # the mode where the provisioning network is optional, so to avoid a
+  # hard dependency of forcing users to specify the interface, we detect
+  # which network interface has the IP's from the machine network.
+  IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
+  PROVISIONING_INTERFACE=$(ip route get "$IP_ONLY" | grep -Po '(?<=(dev )).*(?= src| proto)')
+else
+  # Get rid of any DHCP addresses only if we have a dedicated
+  # provisioning interface
+  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+fi
+
 # Need this to be long enough to bring up the pod with the ip refresh in it.
 # The refresh-static-ip container should lower this back to 10 seconds once it starts.
 # The only time this will actually be set for 5 minutes is if the containers fail to come up.
-/usr/sbin/ip addr add $PROVISIONING_IP dev $PROVISIONING_INTERFACE valid_lft 300 preferred_lft 300
+/usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 300 preferred_lft 300


### PR DESCRIPTION
Setting addr_gen_mode to 0 only works to set the link-local
IP the first time. If this container moves to another node
and then moves back, it needs to be toggled to 1 and back
to take effect.


Also cherry-pick 2 other patches from downstream to make rebases cleaner
"Ensure we don't calculate provisioning interface incorrectly"
"Dynamically detect interface without provisioning network"
